### PR TITLE
Add a Nix-shell development environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ SET(BUILD_HEADLESS false CACHE BOOL "Set to true if you want to build a headless
 SET(USE_QT CACHE BOOL "Use Qt5 to build dedicated server.")
 SET(PANDORA false CACHE BOOL "Build for the Pandora.")
 SET(PYRA false CACHE BOOL "Build for the Pyra.")
+SET(NIXOS false BOOL "Set OpenGL_GL_PREFERENCE for NIXOS.")
+
+IF(NIXOS)
+  SET(OpenGL_GL_PREFERENCE "LEGACY")
+ENDIF()
 
 IF(WIN32)
   SET(CERT "" CACHE FILEPATH "The location of the digital certificate with which to sign your installer.")

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,5 @@
 { pkgs ? import <nixpkgs> {} }:
 
 pkgs.mkShell {
-  nativeBuildInputs = with pkgs; [ cmake SDL2 sfml glew gcc zlib ];
+  nativeBuildInputs = with pkgs; [ cmake SDL2 sfml glew gcc zlib qt5.full ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [ cmake SDL2 sfml glew gcc zlib ];
+}


### PR DESCRIPTION
Hi there, I got your fork to run under NixOS (on a fresh 21.11 vm). With this PR TreadMarks can be built straight out of the box in a `nix-shell` environment.

- Adds shell.nix
- Adds OpenGL_GL_PREFERENCE handling for NixOS to CMakeLists.txt

## Building under NixOS
Run `nix-shell` to enter the nix-shell environment.

Set NIXOS to true in CMakeLists.txt (This step fixes the OpenGL issue explain bellow)

Run `cmake . && make`

## Note regarding OpenGL_GL_PREFERENCE:

Setting it to LEGACY, FindOpenGL goes with libGL.so which works. As seen here:

![unknown](https://user-images.githubusercontent.com/3671250/154633056-825bfe0f-0f76-42af-b286-154bbad44311.png)


Setting it to GLVND results in libOpenGL.so and libGLX.so which builds but has immediately visible issues in the Rolling Demo:

![unknown](https://user-images.githubusercontent.com/3671250/154632712-be11f746-66d6-466a-bb63-40972b5b1230.png)